### PR TITLE
fix: fixed template switching from pro to free mode prod

### DIFF
--- a/src/components/loggedInHeader.jsx
+++ b/src/components/loggedInHeader.jsx
@@ -223,6 +223,7 @@ export default function LoggedInHeader({
 
   const handleUpdate = (open = false) => {
     setUpdateLoading(true);
+    changeTemplate(template)
     _publish({ status: 1 })
       .then((res) => {
         setUserDetails((prev) => ({ ...prev, ...res?.data?.user }));

--- a/src/components/onboarding.jsx
+++ b/src/components/onboarding.jsx
@@ -169,7 +169,11 @@ export default function Onboarding() {
 
   const handleNetwork = (payload, actions) => {
     setLoading(true);
-    _updateUser(payload)
+    const payloadWithTemplate = {
+      ...payload,
+      template: userDetails?.template,
+    };
+    _updateUser(payloadWithTemplate)
       .then((res) => {
         updateCache("userDetails", res?.data?.user);
         setUserDetails((prev) => ({ ...prev, ...res.data.user }));

--- a/src/components/proWarning.jsx
+++ b/src/components/proWarning.jsx
@@ -2,7 +2,7 @@ import { useGlobalContext } from "@/context/globalContext";
 import React from "react";
 import styles from "@/styles/domain.module.css";
 export default function ProWarning() {
-  const { template, setTemplate, setShowUpgradeModal } = useGlobalContext();
+  const { template, setTemplate, setShowUpgradeModal, setTemplateContext } = useGlobalContext();
 
   if (template === 0) return null;
   return (
@@ -29,7 +29,7 @@ export default function ProWarning() {
         </div>
         <button
           className={styles.revertTemplateButton}
-          onClick={() => setTemplate(0)}
+          onClick={() => setTemplateContext(0)}
         >
           Revert to Default
         </button>

--- a/src/context/globalContext.jsx
+++ b/src/context/globalContext.jsx
@@ -189,6 +189,14 @@ export const GlobalProvider = ({ children }) => {
     setStep(1);
   };
 
+  const setTemplateContext = (value) => {
+    setTemplate(value);
+    setUserDetails((prev) => ({
+      ...prev,
+      template: value,
+    }));
+  };
+
   return (
     <GlobalContext.Provider
       value={{
@@ -233,6 +241,7 @@ export const GlobalProvider = ({ children }) => {
         domainDetails,
         setDomainDetails,
         fetchDomainDetails,
+        setTemplateContext
       }}
     >
       {children}


### PR DESCRIPTION
#### Change Summary 

Fixed the syncing for the template version being chosen by the user. Whenever we are doing an update, I am also sending the additional parameter of template so that the server and client are in sync.

#### Change Log 

- Created a new method in global context to ease up template tracking 
- On Update Calls for headline and tools etc, I am also sending the template parameter so that it remains in sync 

@sarathdixit, I have only moved my changes to prod from dev since on doing dev-> prod I saw there were some more commits of yours.